### PR TITLE
Time comparison fix

### DIFF
--- a/cache.go
+++ b/cache.go
@@ -1,32 +1,30 @@
 package cache
 
 import (
-	"time"
-	"strings"
-	"net/http"
-	"net/http/httptest"
 	"github.com/mholt/caddy/caddyhttp/httpserver"
 	"github.com/nicolasazrak/caddy-cache/storage"
 	"github.com/pquerna/cachecontrol"
+	"net/http"
+	"net/http/httptest"
 	"reflect"
+	"strings"
+	"time"
 )
-
 
 type CachedRequest struct {
 	HeaderMap http.Header // Headers are the only useful information
 }
 
 type CachedResponse struct {
-	Code      int           // the HTTP response code from WriteHeader
+	Code      int // the HTTP response code from WriteHeader
 	Body      []byte
-	HeaderMap http.Header   // the HTTP response headers
+	HeaderMap http.Header // the HTTP response headers
 }
 
 type CacheEntry struct {
-	Request *CachedRequest
+	Request  *CachedRequest
 	Response *CachedResponse
 }
-
 
 type CacheHandler struct {
 	Config *Config
@@ -34,8 +32,7 @@ type CacheHandler struct {
 	Next   httpserver.Handler
 }
 
-
-func respond(response * CachedResponse, w http.ResponseWriter) {
+func respond(response *CachedResponse, w http.ResponseWriter) {
 	for k, values := range response.HeaderMap {
 		for _, v := range values {
 			w.Header().Add(k, v)
@@ -105,8 +102,8 @@ func getKey(r *http.Request) string {
 	return r.Method + " " + r.Host + r.URL.Path
 }
 
-func (h CacheHandler) chooseIfVary(r *http.Request) (func (storage.Value) bool) {
-	return func (value storage.Value) bool {
+func (h CacheHandler) chooseIfVary(r *http.Request) func(storage.Value) bool {
+	return func(value storage.Value) bool {
 		entry := value.(*CacheEntry)
 		vary, hasVary := entry.Response.HeaderMap["Vary"]
 		if !hasVary {
@@ -115,7 +112,7 @@ func (h CacheHandler) chooseIfVary(r *http.Request) (func (storage.Value) bool) 
 
 		for _, searchedHeader := range strings.Split(vary[0], ",") {
 			searchedHeader = strings.TrimSpace(searchedHeader)
-			if !reflect.DeepEqual(entry.Request.HeaderMap[searchedHeader], r.Header[searchedHeader])  {
+			if !reflect.DeepEqual(entry.Request.HeaderMap[searchedHeader], r.Header[searchedHeader]) {
 				return false
 			}
 		}
@@ -149,10 +146,10 @@ func (h CacheHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) (int, er
 			Request: &CachedRequest{
 				HeaderMap: r.Header,
 			},
-			Response: &CachedResponse {
-				Body: rec.Body.Bytes(),
+			Response: &CachedResponse{
+				Body:      rec.Body.Bytes(),
 				HeaderMap: rec.HeaderMap,
-				Code: rec.Code,
+				Code:      rec.Code,
 			},
 		}
 

--- a/rules.go
+++ b/rules.go
@@ -1,33 +1,31 @@
 package cache
 
 import (
-	"strings"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 )
-
 
 type CacheRule interface {
 	matches(*http.Request, *httptest.ResponseRecorder) bool
 }
 
 type PathCacheRule struct {
-	Path 		string
+	Path string
 }
 
 type HeaderCacheRule struct {
-	Header 		string
-	Value 		[]string
+	Header string
+	Value  []string
 }
-
 
 /* This rules decide if the request must be cached and are added to handler config if are present in Caddyfile */
 
-func (rule * PathCacheRule) matches(req *http.Request, res *httptest.ResponseRecorder) bool {
+func (rule *PathCacheRule) matches(req *http.Request, res *httptest.ResponseRecorder) bool {
 	return strings.HasPrefix(req.URL.Path, rule.Path)
 }
 
-func (rule * HeaderCacheRule) matches(req *http.Request, res *httptest.ResponseRecorder) bool {
+func (rule *HeaderCacheRule) matches(req *http.Request, res *httptest.ResponseRecorder) bool {
 	headerValue := res.HeaderMap.Get(rule.Header)
 	for _, expectedValue := range rule.Value {
 		if expectedValue == headerValue {
@@ -36,4 +34,3 @@ func (rule * HeaderCacheRule) matches(req *http.Request, res *httptest.ResponseR
 	}
 	return false
 }
-

--- a/setup.go
+++ b/setup.go
@@ -2,21 +2,20 @@ package cache
 
 import (
 	"fmt"
-	"time"
-	"strconv"
 	"github.com/mholt/caddy"
 	"github.com/mholt/caddy/caddyhttp/httpserver"
 	"github.com/nicolasazrak/caddy-cache/storage"
+	"strconv"
+	"time"
 )
 
 const DEFAULT_MAX_AGE = time.Duration(60) * time.Second
 
 type Config struct {
-	CacheRules		[]CacheRule
-	DefaultMaxAge  	time.Duration
-	StatusHeader	string
+	CacheRules    []CacheRule
+	DefaultMaxAge time.Duration
+	StatusHeader  string
 }
-
 
 func init() {
 	httpserver.RegisterDevDirective("cache", "root")
@@ -25,7 +24,6 @@ func init() {
 		Action:     Setup,
 	})
 }
-
 
 func Setup(c *caddy.Controller) error {
 	config, err := cacheParse(c)
@@ -58,9 +56,9 @@ func Setup(c *caddy.Controller) error {
 
 func cacheParse(c *caddy.Controller) (*Config, error) {
 	config := Config{
-		CacheRules: []CacheRule{},
+		CacheRules:    []CacheRule{},
 		DefaultMaxAge: DEFAULT_MAX_AGE,
-		StatusHeader: "",
+		StatusHeader:  "",
 	}
 
 	c.Next() // Skip "cache" literal
@@ -73,43 +71,42 @@ func cacheParse(c *caddy.Controller) (*Config, error) {
 		parameter := c.Val()
 		switch parameter {
 
-			case "match":
-				args := c.RemainingArgs()
-				if len(args) != 0 {
-					return nil, c.Err("Invalid usage of match in cache config.")
-				} else{
-					cacheRules, err := parseMatchRules(c)
-					if err != nil {
-						return nil, err
-					}
-					config.CacheRules = cacheRules
+		case "match":
+			args := c.RemainingArgs()
+			if len(args) != 0 {
+				return nil, c.Err("Invalid usage of match in cache config.")
+			} else {
+				cacheRules, err := parseMatchRules(c)
+				if err != nil {
+					return nil, err
 				}
-			case "default_max_age" :
-				args := c.RemainingArgs()
-				if len(args) != 1 {
-					return nil, c.Err("Invalid usage of default_max_age in cache config.")
-				} else{
-					val, err := strconv.Atoi(args[0])
-					if err != nil || val < 0 {
-						return nil, c.Err("Invalid value of default_max_age")
-					}
-					config.DefaultMaxAge = time.Duration(val) * time.Second
-				}
-			case "status_header":
-				args := c.RemainingArgs()
-				if len(args) != 1 {
-					return nil, c.Err("Invalid usage of status_header in cache config.")
-				} else{
-					config.StatusHeader = args[0]
-				}
-			default:
-				return nil, c.Err("Unknown cache parameter: " + parameter)
+				config.CacheRules = cacheRules
 			}
+		case "default_max_age":
+			args := c.RemainingArgs()
+			if len(args) != 1 {
+				return nil, c.Err("Invalid usage of default_max_age in cache config.")
+			} else {
+				val, err := strconv.Atoi(args[0])
+				if err != nil || val < 0 {
+					return nil, c.Err("Invalid value of default_max_age")
+				}
+				config.DefaultMaxAge = time.Duration(val) * time.Second
+			}
+		case "status_header":
+			args := c.RemainingArgs()
+			if len(args) != 1 {
+				return nil, c.Err("Invalid usage of status_header in cache config.")
+			} else {
+				config.StatusHeader = args[0]
+			}
+		default:
+			return nil, c.Err("Unknown cache parameter: " + parameter)
+		}
 	}
 
 	return &config, nil
 }
-
 
 func parseMatchRules(c *caddy.Controller) ([]CacheRule, error) {
 	if c.Next() && c.Val() != "{" {
@@ -128,14 +125,14 @@ func parseMatchRules(c *caddy.Controller) ([]CacheRule, error) {
 			} else {
 				rules = append(rules, &HeaderCacheRule{
 					Header: args[0],
-					Value: args[1:],
+					Value:  args[1:],
 				})
 			}
 		case "path":
 			args := c.RemainingArgs()
 			if len(args) != 1 {
 				return nil, c.Err("Invalid number of arguments in path condition of match in cache config.")
-			} else{
+			} else {
 				rules = append(rules, &PathCacheRule{
 					Path: args[0],
 				})

--- a/setup_test.go
+++ b/setup_test.go
@@ -1,16 +1,15 @@
 package cache
 
 import (
-	"testing"
-	"github.com/stretchr/testify/assert"
 	"github.com/mholt/caddy"
+	"github.com/stretchr/testify/assert"
 	"strconv"
+	"testing"
 	"time"
 )
 
-
 func TestParsingConfig(t *testing.T) {
-	cacheAssetsRule := PathCacheRule {
+	cacheAssetsRule := PathCacheRule{
 		Path: "/assets",
 	}
 
@@ -20,51 +19,51 @@ func TestParsingConfig(t *testing.T) {
 		expect    Config
 	}{
 		{"cache", false, Config{
-			CacheRules: []CacheRule{},
+			CacheRules:    []CacheRule{},
 			DefaultMaxAge: DEFAULT_MAX_AGE,
 		}},
 		{"cache {\n match { \n path /assets \n} }", false, Config{
-			CacheRules: []CacheRule{ &cacheAssetsRule },
+			CacheRules:    []CacheRule{&cacheAssetsRule},
 			DefaultMaxAge: DEFAULT_MAX_AGE,
 		}},
 		{"cache {\n match { \n path /assets \n path /api  \n} \n}", false, Config{
-			CacheRules:[]CacheRule{
+			CacheRules: []CacheRule{
 				&cacheAssetsRule,
-				&PathCacheRule{ Path: "/api" },
+				&PathCacheRule{Path: "/api"},
 			},
 			DefaultMaxAge: DEFAULT_MAX_AGE,
 		}},
 		{"cache {\n default_max_age 30 \n match { \n path /assets \n } \n}", false, Config{
-			CacheRules: []CacheRule{ &cacheAssetsRule },
+			CacheRules:    []CacheRule{&cacheAssetsRule},
 			DefaultMaxAge: time.Second * time.Duration(30),
 		}},
 		{"cache {\n default_max_age 30 \n match { \n path /public \n } \n}", false, Config{
-			CacheRules: []CacheRule{ &PathCacheRule{ Path: "/public" } },
+			CacheRules:    []CacheRule{&PathCacheRule{Path: "/public"}},
 			DefaultMaxAge: time.Second * time.Duration(30),
 		}},
 		{"cache {\n match { header Content-Type image/png image/gif \n path /assets \n } \n}", false, Config{
-			CacheRules: []CacheRule {
-				&HeaderCacheRule {
+			CacheRules: []CacheRule{
+				&HeaderCacheRule{
 					Header: "Content-Type",
-					Value: []string { "image/png", "image/gif" },
+					Value:  []string{"image/png", "image/gif"},
 				},
 				&cacheAssetsRule,
 			},
 			DefaultMaxAge: DEFAULT_MAX_AGE,
 		}},
 		{"cache {\n status_header X-Custom-Header \n}", false, Config{
-			CacheRules: []CacheRule{},
-			StatusHeader: "X-Custom-Header",
+			CacheRules:    []CacheRule{},
+			StatusHeader:  "X-Custom-Header",
 			DefaultMaxAge: DEFAULT_MAX_AGE,
 		}},
-		{"cache {\n status_header aheader another \n}", true, Config{}}, // status_header with invalid number of parameters
-		{"cache {\n default_max_age anumber \n}", true, Config{}}, // max_age with invalid number
-		{"cache {\n default_max_age 45 morepareters \n}", true, Config{}}, // More parameters
-		{"cache {\n default_max_age \n}", true, Config{}}, // Missing parameters
-		{"cache {\n max_age 50 \n}", true, Config{}}, // Unknown parameters
+		{"cache {\n status_header aheader another \n}", true, Config{}},    // status_header with invalid number of parameters
+		{"cache {\n default_max_age anumber \n}", true, Config{}},          // max_age with invalid number
+		{"cache {\n default_max_age 45 morepareters \n}", true, Config{}},  // More parameters
+		{"cache {\n default_max_age \n}", true, Config{}},                  // Missing parameters
+		{"cache {\n max_age 50 \n}", true, Config{}},                       // Unknown parameters
 		{"cache {\n default_max_age 20 \n max_age 50 \n}", true, Config{}}, // Mixed valid and invalid parameters
-		{"cache {\n match { \n path / ea \n} \n}", true, Config{}}, // Invalid number of parameters in match
-		{"cache {\n match { \n unknown \n} \n}", true, Config{}}, // Unknown condition in match
+		{"cache {\n match { \n path / ea \n} \n}", true, Config{}},         // Invalid number of parameters in match
+		{"cache {\n match { \n unknown \n} \n}", true, Config{}},           // Unknown condition in match
 	}
 
 	for i, test := range tests {
@@ -79,7 +78,7 @@ func TestParsingConfig(t *testing.T) {
 			assert.Error(t, err)
 		} else {
 			assert.NoError(t, err)
-			assert.Equal(t, test.expect, *actual, "Invalid config parsed in test " + strconv.Itoa(i + 1))
+			assert.Equal(t, test.expect, *actual, "Invalid config parsed in test "+strconv.Itoa(i+1))
 		}
 	}
 

--- a/storage/memory.go
+++ b/storage/memory.go
@@ -79,7 +79,7 @@ func (s *MemoryStorage) expire() {
 		for key := range s.contents[bucket] {
 			notExpiredContent := s.contents[bucket][key][:0]
 			for _, entry := range s.contents[bucket][key] {
-				if entry.expiration.Before(time.Now().UTC()) {
+				if entry.expiration.After(time.Now().UTC()) {
 					notExpiredContent = append(notExpiredContent, entry)
 				}
 			}

--- a/storage/memory.go
+++ b/storage/memory.go
@@ -1,21 +1,21 @@
 package storage
 
 import (
-	"time"
-	"sync"
-	"math"
 	"hash/crc32"
+	"math"
+	"sync"
+	"time"
 )
 
 const bucketsSize = 256
 
 type MemoryStorage struct {
 	contents [bucketsSize]map[string][]*CacheEntry
-	mutex [bucketsSize]*sync.RWMutex
+	mutex    [bucketsSize]*sync.RWMutex
 }
 
 type CacheEntry struct {
-	value Value
+	value      Value
 	expiration time.Time
 }
 
@@ -49,15 +49,15 @@ func (s *MemoryStorage) Push(key string, cached Value, expiration time.Time) err
 	defer s.mutex[i].Unlock()
 
 	entries, ok := s.contents[i][key]
-	newEntry := &CacheEntry {
-		value: cached,
+	newEntry := &CacheEntry{
+		value:      cached,
 		expiration: expiration,
 	}
 
 	if ok {
 		s.contents[i][key] = append(entries, newEntry)
 	} else {
-		s.contents[i][key] = []*CacheEntry { newEntry }
+		s.contents[i][key] = []*CacheEntry{newEntry}
 	}
 
 	return nil
@@ -68,7 +68,7 @@ func (s *MemoryStorage) Setup() error {
 		s.mutex[i] = new(sync.RWMutex)
 		s.contents[i] = make(map[string][]*CacheEntry)
 	}
-	go doEvery(time.Duration(1) * time.Second, s.expire)
+	go doEvery(time.Duration(1)*time.Second, s.expire)
 	return nil
 }
 


### PR DESCRIPTION
entry.expiration.Before(time.Now().UTC()) returns true if expiration date is before Now(), therefore discarding entries that haven't expired yet. Fixed by changing it to .After().