### PR TITLE
cache_key configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ For more advanced usages you can use the following parameters:
 - `path`: Path where to store the cached responses. By default it will use the operating system temp folder.
 - `default_max_age`: Max-age to use for matched responses that do not have an explicit expiration. (Default: 5 minutes)
 - `status_header`: Sets a header to add to the response indicating the status. It will respond with: skip, miss or hit. (Default: `X-Cache-Status`)
-- `cache_key`: Configures the cache key using [Placeholders](https://caddyserver.com/docs/placeholders), it supports any of the request placeholders. (Default: `{method} {host}{path}{query}`)
+- `cache_key`: Configures the cache key using [Placeholders](https://caddyserver.com/docs/placeholders), it supports any of the request placeholders. (Default: `{method} {host}{path}?{query}`)
 
 ```
 caddy.test {

--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ For more advanced usages you can use the following parameters:
 - `path`: Path where to store the cached responses. By default it will use the operating system temp folder.
 - `default_max_age`: Max-age to use for matched responses that do not have an explicit expiration. (Default: 5 minutes)
 - `status_header`: Sets a header to add to the response indicating the status. It will respond with: skip, miss or hit. (Default: `X-Cache-Status`)
+- `cache_key`: Configures the cache key using [Placeholders](https://caddyserver.com/docs/placeholders), it supports any of the request placeholders. (Default: `{method} {host}{path}{query}`)
 
 ```
 caddy.test {
@@ -101,9 +102,9 @@ Benchmark files are in `benchmark` folder. Tests were run on my Lenovo G480 with
 - [x] Stream responses while fetching them from upstream
 - [x] Locking concurrent requests to the same path
 - [x] File disk storage for larger objects
+- [x] Add a configuration to not use query params in cache key (via `cache_key` directive)
 - [ ] Purge cache entries [#1](https://github.com/nicolasazrak/caddy-cache/issues/1)
 - [ ] Serve stale content if proxy is down
 - [ ] Punch hole cache
 - [ ] Do conditional requests to revalidate data
 - [ ] Max entries size
-- [ ] Add a configuration to not use query params in cache key

--- a/cache.go
+++ b/cache.go
@@ -11,11 +11,12 @@ import (
 const cacheBucketsSize = 256
 
 type HTTPCache struct {
-	entries     [cacheBucketsSize]map[string][]*HTTPCacheEntry
-	entriesLock [cacheBucketsSize]*sync.RWMutex
+	cacheKeyTemplate string
+	entries          [cacheBucketsSize]map[string][]*HTTPCacheEntry
+	entriesLock      [cacheBucketsSize]*sync.RWMutex
 }
 
-func NewHTTPCache() *HTTPCache {
+func NewHTTPCache(cacheKeyTemplate string) *HTTPCache {
 	entriesLocks := [cacheBucketsSize]*sync.RWMutex{}
 	entries := [cacheBucketsSize]map[string][]*HTTPCacheEntry{}
 
@@ -25,13 +26,14 @@ func NewHTTPCache() *HTTPCache {
 	}
 
 	return &HTTPCache{
-		entries:     entries,
-		entriesLock: entriesLocks,
+		cacheKeyTemplate: cacheKeyTemplate,
+		entries:          entries,
+		entriesLock:      entriesLocks,
 	}
 }
 
 func (cache *HTTPCache) Get(request *http.Request) (*HTTPCacheEntry, bool) {
-	key := getKey(request)
+	key := getKey(cache.cacheKeyTemplate, request)
 	b := cache.getBucketIndexForKey(key)
 	cache.entriesLock[b].RLock()
 	defer cache.entriesLock[b].RUnlock()

--- a/handler_test.go
+++ b/handler_test.go
@@ -1,0 +1,53 @@
+package cache
+
+import (
+	"context"
+	"crypto/tls"
+	"net/http"
+	"strconv"
+	"testing"
+
+	"github.com/mholt/caddy/caddyhttp/httpserver"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCacheKeyTemplating(t *testing.T) {
+	tests := []struct {
+		input  string
+		expect string
+	}{
+		{"{scheme} {host}{uri}", "https example.com/path?with=query"},
+		{"{scheme} {host}", "https example.com"},
+		{"{scheme} {uri}", "https /path?with=query"},
+		{"{scheme}{uri}", "https/path?with=query"},
+		{"{uri}", "/path?with=query"},
+		{"{user}:{uri}", "bob:/path?with=query"},
+	}
+
+	for i, test := range tests {
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			r, err := http.NewRequest("GET", "https://bob:password@example.com/path?with=query", nil)
+			if err != nil {
+				require.NoError(t, err)
+			}
+
+			// Create a new replacer, that will be placed onto the context.
+			replacer := httpserver.NewReplacer(r, nil, "")
+
+			// Add in some custom fields.
+			replacer.Set("user", "bob")
+
+			// Swap out the context and inject the original url into the request.
+			ctx := context.WithValue(r.Context(), httpserver.ReplacerCtxKey, replacer)
+			ctx = context.WithValue(ctx, httpserver.OriginalURLCtxKey, *r.URL)
+			r = r.WithContext(ctx)
+
+			// As the input request contained https, we need to set the req.TLS to something to
+			// match the templating behavior of the httpserver.Replacer.
+			r.TLS = &tls.ConnectionState{}
+
+			actual := getKey(test.input, r)
+			require.Equal(t, test.expect, actual, "Invalid cache key computed in test "+strconv.Itoa(i+1))
+		})
+	}
+}

--- a/setup.go
+++ b/setup.go
@@ -57,7 +57,7 @@ func Setup(c *caddy.Controller) error {
 
 // defaultCacheKeyTemplate is the placeholder template that will be used to
 // generate the cache key.
-const defaultCacheKeyTemplate = "{method} {host}{path}{query}"
+const defaultCacheKeyTemplate = "{method} {host}{path}?{query}"
 
 func emptyConfig() *Config {
 	return &Config{

--- a/setup.go
+++ b/setup.go
@@ -17,11 +17,12 @@ var (
 )
 
 type Config struct {
-	StatusHeader  string
-	DefaultMaxAge time.Duration
-	LockTimeout   time.Duration
-	CacheRules    []CacheRule
-	Path          string
+	StatusHeader     string
+	DefaultMaxAge    time.Duration
+	LockTimeout      time.Duration
+	CacheRules       []CacheRule
+	Path             string
+	CacheKeyTemplate string
 }
 
 func init() {
@@ -54,13 +55,18 @@ func Setup(c *caddy.Controller) error {
 	return nil
 }
 
+// defaultCacheKeyTemplate is the placeholder template that will be used to
+// generate the cache key.
+const defaultCacheKeyTemplate = "{method} {host}{path}{query}"
+
 func emptyConfig() *Config {
 	return &Config{
-		StatusHeader:  defaultStatusHeader,
-		DefaultMaxAge: defaultMaxAge,
-		LockTimeout:   defaultLockTimeout,
-		CacheRules:    []CacheRule{},
-		Path:          defaultPath,
+		StatusHeader:     defaultStatusHeader,
+		DefaultMaxAge:    defaultMaxAge,
+		LockTimeout:      defaultLockTimeout,
+		CacheRules:       []CacheRule{},
+		Path:             defaultPath,
+		CacheKeyTemplate: defaultCacheKeyTemplate,
 	}
 }
 
@@ -118,6 +124,11 @@ func cacheParse(c *caddy.Controller) (*Config, error) {
 			}
 			cacheRule := &PathCacheRule{Path: args[0]}
 			config.CacheRules = append(config.CacheRules, cacheRule)
+		case "cache_key":
+			if len(args) != 1 {
+				return nil, c.Err("Invalid usage of cache_key in cache config.")
+			}
+			config.CacheKeyTemplate = args[0]
 		default:
 			return nil, c.Err("Unknown cache parameter: " + parameter)
 		}

--- a/setup_test.go
+++ b/setup_test.go
@@ -16,16 +16,18 @@ func TestParsingConfig(t *testing.T) {
 		expect    Config
 	}{
 		{"cache", false, Config{
-			StatusHeader:  defaultStatusHeader,
-			LockTimeout:   defaultLockTimeout,
-			DefaultMaxAge: defaultMaxAge,
-			CacheRules:    []CacheRule{},
+			StatusHeader:     defaultStatusHeader,
+			LockTimeout:      defaultLockTimeout,
+			DefaultMaxAge:    defaultMaxAge,
+			CacheRules:       []CacheRule{},
+			CacheKeyTemplate: defaultCacheKeyTemplate,
 		}},
 		{"cache {\n match_path /assets \n} }", false, Config{
-			StatusHeader:  defaultStatusHeader,
-			LockTimeout:   defaultLockTimeout,
-			DefaultMaxAge: defaultMaxAge,
-			CacheRules:    []CacheRule{&PathCacheRule{Path: "/assets"}},
+			StatusHeader:     defaultStatusHeader,
+			LockTimeout:      defaultLockTimeout,
+			DefaultMaxAge:    defaultMaxAge,
+			CacheRules:       []CacheRule{&PathCacheRule{Path: "/assets"}},
+			CacheKeyTemplate: defaultCacheKeyTemplate,
 		}},
 		{"cache {\n match_path /assets \n match_path /api \n} \n}", false, Config{
 			StatusHeader:  defaultStatusHeader,
@@ -35,6 +37,7 @@ func TestParsingConfig(t *testing.T) {
 				&PathCacheRule{Path: "/assets"},
 				&PathCacheRule{Path: "/api"},
 			},
+			CacheKeyTemplate: defaultCacheKeyTemplate,
 		}},
 		{"cache {\n match_header Content-Type image/png image/gif \n match_path /assets \n}", false, Config{
 			StatusHeader:  defaultStatusHeader,
@@ -44,31 +47,43 @@ func TestParsingConfig(t *testing.T) {
 				&HeaderCacheRule{Header: "Content-Type", Value: []string{"image/png", "image/gif"}},
 				&PathCacheRule{Path: "/assets"},
 			},
+			CacheKeyTemplate: defaultCacheKeyTemplate,
 		}},
 		{"cache {\n status_header X-Custom-Header \n}", false, Config{
-			StatusHeader:  "X-Custom-Header",
-			LockTimeout:   defaultLockTimeout,
-			DefaultMaxAge: defaultMaxAge,
-			CacheRules:    []CacheRule{},
+			StatusHeader:     "X-Custom-Header",
+			LockTimeout:      defaultLockTimeout,
+			DefaultMaxAge:    defaultMaxAge,
+			CacheRules:       []CacheRule{},
+			CacheKeyTemplate: defaultCacheKeyTemplate,
 		}},
 		{"cache {\n path /tmp/caddy \n}", false, Config{
-			StatusHeader:  defaultStatusHeader,
-			LockTimeout:   defaultLockTimeout,
-			DefaultMaxAge: defaultMaxAge,
-			CacheRules:    []CacheRule{},
-			Path:          "/tmp/caddy",
+			StatusHeader:     defaultStatusHeader,
+			LockTimeout:      defaultLockTimeout,
+			DefaultMaxAge:    defaultMaxAge,
+			CacheRules:       []CacheRule{},
+			Path:             "/tmp/caddy",
+			CacheKeyTemplate: defaultCacheKeyTemplate,
 		}},
 		{"cache {\n lock_timeout 1s \n}", false, Config{
-			StatusHeader:  defaultStatusHeader,
-			LockTimeout:   time.Duration(1) * time.Second,
-			DefaultMaxAge: defaultMaxAge,
-			CacheRules:    []CacheRule{},
+			StatusHeader:     defaultStatusHeader,
+			LockTimeout:      time.Duration(1) * time.Second,
+			DefaultMaxAge:    defaultMaxAge,
+			CacheRules:       []CacheRule{},
+			CacheKeyTemplate: defaultCacheKeyTemplate,
 		}},
 		{"cache {\n default_max_age 1h \n}", false, Config{
-			StatusHeader:  defaultStatusHeader,
-			LockTimeout:   defaultLockTimeout,
-			DefaultMaxAge: time.Duration(1) * time.Hour,
-			CacheRules:    []CacheRule{},
+			StatusHeader:     defaultStatusHeader,
+			LockTimeout:      defaultLockTimeout,
+			DefaultMaxAge:    time.Duration(1) * time.Hour,
+			CacheRules:       []CacheRule{},
+			CacheKeyTemplate: defaultCacheKeyTemplate,
+		}},
+		{"cache {\n cache_key \"{scheme} {host}{uri}\" \n}", false, Config{
+			StatusHeader:     defaultStatusHeader,
+			LockTimeout:      defaultLockTimeout,
+			DefaultMaxAge:    defaultMaxAge,
+			CacheRules:       []CacheRule{},
+			CacheKeyTemplate: "{scheme} {host}{uri}",
 		}},
 		{"cache {\n match_header aheader \n}", true, Config{}},          // match_header without value
 		{"cache {\n lock_timeout aheader \n}", true, Config{}},          // lock_timeout with invalid duration
@@ -79,6 +94,7 @@ func TestParsingConfig(t *testing.T) {
 		{"cache {\n match_path / ea \n}", true, Config{}},               // Invalid number of parameters in match
 		{"cache {\n invalid / ea \n}", true, Config{}},                  // Invalid directive
 		{"cache {\n path \n}", true, Config{}},                          // Path without arguments
+		{"cache {\n cache_key \n}", true, Config{}},                     // cache_key without arguments
 	}
 
 	for i, test := range tests {


### PR DESCRIPTION
This PR serves to add support to caddy-cache for configuring the cache key used using Caddy [Placeholders](https://caddyserver.com/docs/placeholders).

## Examples

### Ignore the query string

```
cache { cache_key "{method} {host}{path}" }
```

```
Request: GET https://example.com/test?some=variable
Cache Key: GET example.com/test
```

### Cache per user (via basic auth)

```
cache { cache_key "{method} {host}{path}?{query} {user}" }
```

```
Request: GET https://bob:my-password@example.com/test?some=variable
Cache Key: GET example.com/test?some=variable bob
```

## :rotating_light: Caveats :rotating_light:

**Note**: This may/may not  be an issue, but using placeholders, it's currently not possible to do conditional operations like you see here:

https://github.com/nicolasazrak/caddy-cache/blob/a00a842f2578bd6be07bc21f004c3312a107c0ab/handler.go#L49-L52

So instead, the default cache key reads: `{method} {host}{path}?{query}` which when for example, a request comes in as `GET https://example.com/test`, the cache key will be `GET example.com/test?` instead of the current `GET example.com/test`. This will result in entries that are invalidated, because of the additional `?`, but besides that, I think it's more flexible.